### PR TITLE
fix: 価格を取得するメソッドを呼び出す

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,8 +5,8 @@
   "prettier.configPath": "./prettierrc.js",
   "stylelint.configFile": "./.stylelintrc.js",
   "editor.codeActionsOnSave": {
-    "source.fixAll.stylelint": true,
-    "source.fixAll.eslint": true
+    "source.fixAll.stylelint": "explicit",
+    "source.fixAll.eslint": "explicit"
   },
   "editor.tabSize": 2
 }

--- a/src/public/index.php
+++ b/src/public/index.php
@@ -1,2 +1,46 @@
 <?php
-echo 'Welcome TECH QUEST!';
+   
+$purchasedItemPriceList[] = new PurchasedItemPrice(500);
+$purchasedItemPriceList[] = new PurchasedItemPrice(2000);
+$purchasedItemPriceList[] = new PurchasedItemPrice(5000);
+$purchasedItemPriceCollection = new PurchasedItemPriceCollection($purchasedItemPriceList);
+
+// 購入した商品の合計金額を出力しています。
+echo $purchasedItemPriceCollection->findTotalPurchasedItemPrice();
+
+
+// プロパティに「購入した商品の金額」を持ち、「購入した商品の金額を返す」メソッドを持つクラスです。
+class PurchasedItemPrice
+{
+    private $purchasedItemPrice;
+ 
+    public function __construct(int $purchasedItemPrice)
+    {
+        $this->purchasedItemPrice = $purchasedItemPrice;
+    }
+    public function purchasedItemPrice()
+    {
+        return $this->purchasedItemPrice;
+    }
+}
+
+// プロパティに「クラスがいくつか入っている配列」を持ち、「購入した商品の合計金額を返す」メソッドを持つクラスです。
+class PurchasedItemPriceCollection
+{
+    private $purchasedItemPriceList;
+ 
+    public function __construct(array $purchasedItemPriceList)
+    {
+        $this->purchasedItemPriceList = $purchasedItemPriceList;
+    }
+
+    public function findTotalPurchasedItemPrice()
+    {
+        $totalPurchasedItemPrice = 0;
+        foreach ($this->purchasedItemPriceList as $purchasedItemPrice) {
+            // 修正点：各オブジェクトの価格を取得するメソッドを呼び出す
+            $totalPurchasedItemPrice += $purchasedItemPrice->purchasedItemPrice();
+        }
+        return $totalPurchasedItemPrice;
+    }
+}


### PR DESCRIPTION
PurchasedItemPriceCollectionクラスの修正

$this->purchasedItemPriceList内の各PurchasedItemPriceオブジェクトの金額を合計するため、ループ内で各オブジェクトのpurchasedItemPriceメソッドを呼び出して金額を取得する

教材リンク
https://round-petunia-b6f.notion.site/2-152885702b524543a57629a6057e416c